### PR TITLE
Stricter tests

### DIFF
--- a/test/test.ls
+++ b/test/test.ls
@@ -10,7 +10,13 @@ describe "Validate Twitter Handle:" (_) ->
     given = "twitter"
     actual = validate(given)
     expect(actual).to.eql(expected)
-
+    
+  it "It should not accept latin characters" ->
+    expected = false
+    given = "@twittér"
+    actual = validate(given)
+    expect(actual).to.eql(expected)
+    
   it "It should accept an '_'" ->
     expected = true
     given = "@twitter_handle"


### PR DESCRIPTION
Following along with:
https://support.twitter.com/articles/101299#error

\w matches non-latin characters
[A-Za-z0-9_] is what twitter appears to want.